### PR TITLE
Set version to 1.0.0

### DIFF
--- a/elfcore/Cargo.toml
+++ b/elfcore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elfcore"
-version = "0.1.0"
+version = "1.0.0"
 edition = "2021"
 description = "elfcore is a crate to create ELF core dumps for processes on Linux."
 license = "MIT"


### PR DESCRIPTION
We're already using this in reasonably mature projects and we don't have any plans to change the API, so releasing this as 1.0.0 makes sense.