### PR TITLE
Bump to 1.0.1

### DIFF
--- a/elfcore/Cargo.toml
+++ b/elfcore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elfcore"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 description = "elfcore is a crate to create ELF core dumps for processes on Linux."
 license = "MIT"


### PR DESCRIPTION
No functional change, just making it so the README and LICENSE file end up in crates.io.