### PR TITLE
Use `process_vm_readv` to increase speed

### DIFF
--- a/elfcore/src/coredump.rs
+++ b/elfcore/src/coredump.rs
@@ -768,10 +768,6 @@ impl ProcessView {
             },
             Err(_) => 0x1000_usize,
         };
-        assert!(
-            page_size.is_power_of_two(),
-            "Page size is expected to be a power of 2"
-        );
 
         Ok(Self {
             pid,
@@ -1357,8 +1353,13 @@ fn write_va_region<T: Write>(
                 //
                 // Save dummy data up to the next page boundary.
 
-                // Page size is a power of 2 on modern platforms, that is asserted in
-                // the `ProcessView`'s constructor. Round up with bit twiddling.
+                // Page size is a power of two on modern platforms.
+                debug_assert!(
+                    pv.page_size.is_power_of_two(),
+                    "Page size is expected to be a power of two"
+                );
+
+                // Round up with bit twiddling as the page size is a power of two.
                 let next_address = (pv.page_size + address as usize) & !(pv.page_size - 1);
                 let next_address = std::cmp::min(next_address, va_region.end as usize);
                 let dummy_data_size = next_address - address as usize;

--- a/elfcore/src/coredump.rs
+++ b/elfcore/src/coredump.rs
@@ -16,6 +16,9 @@ use nix::libc::Elf64_Phdr;
 use nix::sys;
 use nix::sys::ptrace::seize;
 use nix::sys::ptrace::Options;
+use nix::sys::uio::process_vm_readv;
+use nix::sys::uio::IoVec;
+use nix::sys::uio::RemoteIoVec;
 use nix::sys::wait::waitpid;
 use nix::unistd::sysconf;
 use nix::unistd::Pid;
@@ -23,14 +26,11 @@ use nix::unistd::SysconfVar;
 use smallvec::smallvec;
 use smallvec::SmallVec;
 use std::collections::HashSet;
-use std::ffi::c_void;
 use std::fs;
 use std::fs::File;
 use std::io::BufRead;
 use std::io::Read;
 use std::io::Write;
-use std::os::unix::fs::FileExt;
-use std::os::unix::io::AsRawFd;
 use std::slice;
 use zerocopy::AsBytes;
 
@@ -361,7 +361,6 @@ struct NoteSizes {
 /// View of a Linux light-weight process
 pub struct ProcessView {
     pid: Pid,
-    mem: File,
     threads: Vec<ThreadView>,
     va_regions: Vec<VaRegion>,
     mapped_files: Vec<MappedFile>,
@@ -427,10 +426,7 @@ fn get_aux_vector(pid: Pid) -> Result<Vec<Elf64_Auxv>, CoreError> {
     Ok(auxv)
 }
 
-fn get_va_regions(
-    pid: Pid,
-    mem: &mut File,
-) -> Result<(Vec<VaRegion>, Vec<MappedFile>, u64), CoreError> {
+fn get_va_regions(pid: Pid) -> Result<(Vec<VaRegion>, Vec<MappedFile>, u64), CoreError> {
     let mut maps: Vec<VaRegion> = Vec::new();
     let mut vdso = 0_u64;
 
@@ -521,16 +517,29 @@ fn get_va_regions(
                 // as it might be quite huge and may contains secrets, filter out by default.
                 // TODO: make optional.
 
-                // SAFETY: reading other process memory. The process is paused, the address
-                // comes from the kernel. The structure is repr(C) with no padding bytes,
-                // so all byte patterns are valid.
-                let maybe_elf_hdr = unsafe {
-                    let mut elf_hdr: Elf64_Ehdr = std::mem::zeroed();
-                    let elf_hdr_slice = slice::from_raw_parts_mut(
-                        &mut elf_hdr as *mut _ as *mut u8,
-                        std::mem::size_of::<Elf64_Ehdr>(),
-                    );
-                    match mem.read_exact_at(elf_hdr_slice, begin) {
+                let maybe_elf_hdr = {
+                    // SAFETY: while the all-zero byte content does not represent
+                    // a semantically valid value, the code below checks for the
+                    // correctness.
+                    let mut elf_hdr: Elf64_Ehdr = unsafe { std::mem::zeroed() };
+
+                    // SAFETY: creating a mutable byte slice from the `elf_hdr` space, using
+                    // the correct address and the correct size.
+                    let elf_hdr_slice = unsafe {
+                        slice::from_raw_parts_mut(
+                            &mut elf_hdr as *mut _ as *mut u8,
+                            std::mem::size_of::<Elf64_Ehdr>(),
+                        )
+                    };
+
+                    match process_vm_readv(
+                        pid,
+                        &[IoVec::from_mut_slice(elf_hdr_slice)],
+                        &[RemoteIoVec {
+                            base: begin as usize,
+                            len: std::mem::size_of::<Elf64_Ehdr>(),
+                        }],
+                    ) {
                         Ok(_) => Some(elf_hdr),
                         Err(_) => None,
                     }
@@ -696,11 +705,6 @@ impl ProcessView {
     pub fn new(pid: libc::pid_t) -> Result<Self, CoreError> {
         let pid = nix::unistd::Pid::from_raw(pid);
 
-        // Trying to open the memory file first
-        let mem_path = format!("/proc/{}/mem", pid);
-        tracing::debug!("Reading {mem_path}");
-        let mut mem = File::open(mem_path)?;
-
         let mut tids = get_thread_ids(pid)?;
         tids.sort();
 
@@ -760,7 +764,7 @@ impl ProcessView {
             tracing::debug!("Thread state: {:x?}", thread);
         }
 
-        let (va_regions, mapped_files, vdso) = get_va_regions(pid, &mut mem)?;
+        let (va_regions, mapped_files, vdso) = get_va_regions(pid)?;
 
         tracing::debug!("VA regions {:x?}", va_regions);
         tracing::debug!("Mapped files {:x?}", mapped_files);
@@ -770,20 +774,25 @@ impl ProcessView {
 
         tracing::debug!("Auxiliary vector {:x?}", aux_vector);
 
+        let page_size = match sysconf(SysconfVar::PAGE_SIZE) {
+            Ok(s) => match s {
+                Some(s) => s as usize,
+                None => 0x1000_usize,
+            },
+            Err(_) => 0x1000_usize,
+        };
+        assert!(
+            page_size.is_power_of_two(),
+            "Page size is expected to be a power of 2"
+        );
+
         Ok(Self {
             pid,
-            mem,
             threads,
             va_regions,
             mapped_files,
             aux_vector,
-            page_size: match sysconf(SysconfVar::PAGE_SIZE) {
-                Ok(s) => match s {
-                    Some(s) => s as usize,
-                    None => 0x1000_usize,
-                },
-                Err(_) => 0x1000_usize,
-            },
+            page_size,
         })
     }
 }
@@ -1328,28 +1337,53 @@ fn write_va_region<T: Write>(
     va_region: &VaRegion,
     pv: &ProcessView,
 ) -> Result<usize, CoreError> {
+    // For optimal performance should be in [8KiB; 64KiB] range.
+    // Selected 64 KiB as data on various hardware platforms shows
+    // peak performance in this case.
+    const BUFFER_SIZE: usize = 0x10000;
+
     let mut dumped = 0_usize;
     let mut address = va_region.begin;
+    let mut buffer = [0_u8; BUFFER_SIZE];
 
     while address < va_region.end {
-        let mut page = vec![0xF1_u8; pv.page_size];
+        let len = std::cmp::min((va_region.end - address) as usize, BUFFER_SIZE);
+        match process_vm_readv(
+            pv.pid,
+            &[IoVec::from_mut_slice(&mut buffer)],
+            &[RemoteIoVec {
+                base: address as usize,
+                len,
+            }],
+        ) {
+            Ok(bytes_read) => {
+                writer.write_all(&buffer[..bytes_read])?;
 
-        // SAFETY: Reading other process memory. The process is paused,
-        // the address comes from the kernel. The structure is repr(C) with no padding bytes,
-        // so all byte patterns are valid.
-        let _bytes_read = unsafe {
-            nix::libc::pread64(
-                pv.mem.as_raw_fd(),
-                page.as_mut_ptr() as *const _ as *mut c_void,
-                page.len(),
-                address as i64,
-            )
-        };
+                address += bytes_read as u64;
+                dumped += bytes_read;
+            }
+            Err(_) => {
+                // Every precaution has been taken to read the accessible
+                // memory only and still something has gone wrong. Nevertheless,
+                // have to make forward progress to dump exactly as much memory
+                // as the caller expects.
+                //
+                // Save dummy data up to the next page boundary.
 
-        writer.write_all(page.as_bytes())?;
+                // Page size is a power of 2 on modern platforms, that is asserted in
+                // the `ProcessView`'s constructor. Round up with bit twiddling.
+                let next_address = (pv.page_size + address as usize) & !(pv.page_size - 1);
+                let next_address = std::cmp::min(next_address, va_region.end as usize);
+                let dummy_data_size = next_address - address as usize;
 
-        address += pv.page_size as u64;
-        dumped += page.as_bytes().len();
+                let dummy_data: SmallVec<[u8; BUFFER_SIZE]> = smallvec![0xf1_u8; dummy_data_size];
+
+                writer.write_all(&dummy_data[..dummy_data_size])?;
+
+                address = next_address as u64;
+                dumped += dummy_data_size;
+            }
+        }
     }
 
     Ok(dumped)

--- a/elfcore/src/elf.rs
+++ b/elfcore/src/elf.rs
@@ -63,7 +63,7 @@ pub const NT_FILE: u32 = 0x46494c45;
 
 /// Program status
 #[derive(AsBytes)]
-#[repr(C, packed)]
+#[repr(C)]
 pub struct prpsinfo_t {
     // total size (bytes):  136
     pub pr_state: u8,
@@ -84,7 +84,7 @@ pub struct prpsinfo_t {
 
 /// Signal information
 #[derive(AsBytes)]
-#[repr(C, packed)]
+#[repr(C)]
 pub struct siginfo_t {
     // total size (bytes):  128
     pub si_signo: u32,
@@ -95,16 +95,16 @@ pub struct siginfo_t {
 }
 
 /// Kernel time value
-#[repr(C, packed)]
 #[derive(AsBytes)]
+#[repr(C)]
 pub struct pr_timeval_t {
     pub tv_sec: u64,
     pub tv_usec: u64,
 }
 
 /// Program status
-#[repr(C, packed)]
 #[derive(AsBytes)]
+#[repr(C)]
 pub struct prstatus_t {
     // total size (bytes):  336 (x86_64)
     pub si_signo: u32,
@@ -128,9 +128,8 @@ pub struct prstatus_t {
 }
 
 /// ELF auxiliary vector note
-#[derive(AsBytes, FromBytes)]
-#[repr(C, packed)]
-#[derive(Clone, Copy, Debug)]
+#[derive(AsBytes, FromBytes, Clone, Copy, Debug)]
+#[repr(C)]
 pub struct Elf64_Auxv {
     pub a_type: u64, // from auxvec.h
     pub a_val: u64,
@@ -138,9 +137,29 @@ pub struct Elf64_Auxv {
 
 /// ELF note header
 #[derive(AsBytes)]
-#[repr(C, packed)]
+#[repr(C)]
 pub struct Elf64_Nhdr {
     pub namesz: u32,
     pub descsz: u32,
     pub ntype: u32,
+}
+
+/// ELF header
+#[derive(AsBytes, FromBytes)]
+#[repr(C)]
+pub struct Elf64_Ehdr {
+    pub e_ident: [u8; 16],
+    pub e_type: u16,
+    pub e_machine: u16,
+    pub e_version: u32,
+    pub e_entry: u64,
+    pub e_phoff: u64,
+    pub e_shoff: u64,
+    pub e_flags: u32,
+    pub e_ehsize: u16,
+    pub e_phentsize: u16,
+    pub e_phnum: u16,
+    pub e_shentsize: u16,
+    pub e_shnum: u16,
+    pub e_shstrndx: u16,
 }


### PR DESCRIPTION
## Motivation

This crate uses the Linux-specific [`ptrace`](https://man7.org/linux/man-pages/man2/ptrace.2.html) API, and there is no reason not to use the [`process_vm_readv`](https://man7.org/linux/man-pages/man2/process_vm_readv.2.html) system call available on Linux kernels 3.2+. [Microbenchmark](https://github.com/kromych/proc_mem_bench) shows that this is going to be faster when saving process memory compared to reading the `/dev/{pid}/mem` file.

## Changes

1. Replaced reading the the `/dev/{pid}/mem` file with `process_vm_readv`.
2. Removed dynamic allocation from the memory reading loop.

## Validation

For validation, I captured dump files of `sleep` and `yes` to make sure the debugger can resolve the stack.
Time-wise, the changes in this PR let the dump file be created notably faster. Here is a log of creating a dump file off of some vscode utility process:

```
# With changes
# ========================================================================================

[krom@krom-9550 elfcore]$ time target/release/elfcore-sample 5340 core.5340
real	0m0.255s
user	0m0.002s
sys	0m0.205s

[krom@krom-9550 elfcore]$ time target/release/elfcore-sample 5340 core.5340
real	0m0.270s
user	0m0.006s
sys	0m0.217s

[krom@krom-9550 elfcore]$ time target/release/elfcore-sample 5340 core.5340
real	0m0.260s
user	0m0.004s
sys	0m0.209s

# Without changes
# ========================================================================================

[krom@krom-9550 elfcore]$ time target/release/elfcore-sample 5340 core.5340
real	0m0.415s
user	0m0.029s
sys	0m0.336s

[krom@krom-9550 elfcore]$ time target/release/elfcore-sample 5340 core.5340
real	0m0.409s
user	0m0.019s
sys	0m0.345s

[krom@krom-9550 elfcore]$ time target/release/elfcore-sample 5340 core.5340
real	0m0.400s
user	0m0.017s
sys	0m0.334s

#============================================================================================

[krom@krom-9550 elfcore]$ ll -lh
total 260M
-rw-r--r--. 1 krom krom 8.3K Jun 12 19:20 Cargo.lock
-rw-r--r--. 1 krom krom  243 Jun 12 19:19 Cargo.toml
drwxr-xr-x. 1 krom krom   44 Jun 12 19:19 ci
-rw-r--r--. 1 krom krom  444 Jun 12 19:19 CODE_OF_CONDUCT.md
-rw-r--r--. 1 krom krom 257M Jun 12 20:36 core.5340
```