### PR TITLE
release: release version 2.0

### DIFF
--- a/elfcore/Cargo.toml
+++ b/elfcore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elfcore"
-version = "1.1.5"
+version = "2.0.0"
 edition = "2021"
 description = "elfcore is a crate to create ELF core dumps for processes on Linux."
 license = "MIT"


### PR DESCRIPTION
Release version 2.0 that includes a breaking change to support a trait based method of building coredumps from #34. 