### PR TITLE
fix: move #[cfg(target_os = linux)] from fn new() to impl block

### DIFF
--- a/elfcore/src/coredump.rs
+++ b/elfcore/src/coredump.rs
@@ -970,9 +970,9 @@ pub struct CoreDumpBuilder<'a, P: ProcessInfoSource, M: ReadProcessMemory> {
     memory_reader: M,
 }
 
+#[cfg(target_os = "linux")]
 impl<'a> CoreDumpBuilder<'a, ProcessView, LinuxProcessMemoryReader> {
     /// Create a new core dump builder for the process with the provided PID
-    #[cfg(target_os = "linux")]
     pub fn new(
         pid: libc::pid_t,
     ) -> Result<CoreDumpBuilder<'a, ProcessView, LinuxProcessMemoryReader>, CoreError> {


### PR DESCRIPTION
The impl block references Linux-only types (ProcessView, LinuxProcessMemoryReader) unconditionally, breaking compilation on non-Linux targets on v2.0.1. (see https://github.com/hyperlight-dev/hyperlight/pull/1288 for an example)

aside: Would you be open to adding windows comiplation/tests to CI to prevent future breakage?

